### PR TITLE
[Settings⚙️] #3 아키텍처 기본 구성 및 핵심 Alarm 로직 구성 

### DIFF
--- a/PalangPalang/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/PalangPalang/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PalangPalang/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/PalangPalang/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PalangPalang/Resources/Assets.xcassets/Contents.json
+++ b/PalangPalang/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PalangPalang/Resources/InfoPlists/PalangPalang-Info.plist
+++ b/PalangPalang/Resources/InfoPlists/PalangPalang-Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(BUNDLE_VERSION_STRING)</string>
+	<key>CFBundleVersion</key>
+	<string>$(BUNDLE_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/PalangPalang/Resources/InfoPlists/PalangPalangTests-Info.plist
+++ b/PalangPalang/Resources/InfoPlists/PalangPalangTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PalangPalang/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/PalangPalang/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PalangPalang/Sources/App/AppDelegate.swift
+++ b/PalangPalang/Sources/App/AppDelegate.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions:
+    [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let appView = AppView()
+    window = UIWindow(frame: UIScreen.main.bounds)
+    window?.rootViewController = UIHostingController(rootView: appView)
+    window?.makeKeyAndVisible()
+    return true
+  }
+}

--- a/PalangPalang/Sources/App/AppView.swift
+++ b/PalangPalang/Sources/App/AppView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct AppView: View {
+  let appState = AlarmUseCase.shared
+  
+  var body: some View {
+    switch appState.alarmState {
+    case .alarmOnSettings:
+      AlarmMainView()
+    case .alarmOnProcess:
+      AlarmOnProcessView()
+    case .missionOnProcess:
+      MissionOnProcessView()
+    case .missionTimeout:
+      MissionTimeoutView()
+    }
+  }
+}
+
+#Preview {
+  AlarmMainView()
+}

--- a/PalangPalang/Sources/Data/Services/DataStoreService.swift
+++ b/PalangPalang/Sources/Data/Services/DataStoreService.swift
@@ -1,0 +1,35 @@
+//
+//  DataService.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+struct DataStoreService<T: Storable> {
+  func save(_ item: T) {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    do {
+      let data = try encoder.encode(item)
+      UserDefaults.standard.set(data, forKey: T.storageKey)
+      print("UserDefaults에 새로운 데이터 저장됨")
+    } catch {
+      print("데이터 저장 실패: \(error)")
+    }
+  }
+  
+  func load() -> T? {
+    guard let savedData = UserDefaults.standard.data(forKey: T.storageKey) else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try? decoder.decode(T.self, from: savedData)
+  }
+  
+  func remove() {
+    UserDefaults.standard.removeObject(forKey: T.storageKey)
+    print("UserDefaults에서 데이터 제거됨")
+  }
+}

--- a/PalangPalang/Sources/Data/Services/LocalNotificationService.swift
+++ b/PalangPalang/Sources/Data/Services/LocalNotificationService.swift
@@ -1,0 +1,61 @@
+//
+//  LocalNotificationService.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - 로컬 알림 설정
+struct LocalNotificationService {
+  init() {
+    requestNotificationPermission()
+  }
+  
+  // 알림 권한 요청
+  private func requestNotificationPermission() {
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+      if let error = error {
+        print("알림 권한 요청 오류: \(error)")
+      }
+    }
+  }
+  
+  // 특정 시간에 알림 예약
+  func scheduleNotification(title: String, body: String, at date: Date) {
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = .default
+    
+    let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+    let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
+    
+    let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+    
+    UNUserNotificationCenter.current().add(request) { error in
+      if let error = error {
+        print("알림 예약 실패: \(error)")
+      }
+    }
+  }
+  
+  // 즉시 알림 발송
+  func sendNotification(title: String, body: String) {
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = .default
+    
+    let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+    
+    UNUserNotificationCenter.current().add(request) { error in
+      if let error = error {
+        print("즉시 알림 발송 실패: \(error)")
+      }
+    }
+  }
+}

--- a/PalangPalang/Sources/Data/Services/TimerSchedulerService.swift
+++ b/PalangPalang/Sources/Data/Services/TimerSchedulerService.swift
@@ -1,0 +1,77 @@
+//
+//  TimerSchedulerService.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - 설정한 알람의 시간과 미션 종료 시간을 감지하고 알려주는 메서드
+class TimerSchedulerService {
+  let onMissionStart: () -> Void
+  let onMissionTimeout: () -> Void
+  private var alarmTimer: Timer?
+  private var missionTimer: Timer?
+  
+  init(alarm: AlarmModel? = nil, onMissionStart: @escaping () -> Void, onMissionFinish: @escaping () -> Void) {
+    self.onMissionStart = onMissionStart
+    self.onMissionTimeout = onMissionFinish
+    guard let alarm else { return }
+    scheduleAlarmAndMissionTimers(alarm)
+  }
+
+  func scheduleAlarmAndMissionTimers(_ alarm: AlarmModel) {
+    scheduleAlarmNotification(dueDate: alarm.dueDate)
+    scheduleMissionNotification(missionCompleted: alarm.missionDueDate)
+  }
+  
+  // 모든 타이머를 종료하는 메서드
+  func invalidateAllTimers() {
+    invalidateAlarmTimer()
+    invalidateMissionTimer()
+    print("모든 타이머가 종료되었습니다.")
+  }
+  
+  // 미션 시작시간에 알림 설정
+  private func scheduleAlarmNotification(dueDate: Date) {
+    let timeInterval = dueDate.timeIntervalSinceNow
+    guard timeInterval > 0 else { return }
+      alarmTimer = Timer.scheduledTimer(timeInterval: timeInterval, target: self, selector: #selector(startMission), userInfo: nil, repeats: false)
+  }
+  
+  // 미션 시간오버 시간에 알림 설정
+  private func scheduleMissionNotification(missionCompleted: Date) {
+    let timeInterval = missionCompleted.timeIntervalSinceNow
+    guard timeInterval > 0 else { return }
+      missionTimer = Timer.scheduledTimer(timeInterval: timeInterval, target: self, selector: #selector(timeoutMission), userInfo: nil, repeats: false)
+  }
+  
+  // 개별 타이머 종료 메서드
+  private func invalidateAlarmTimer() {
+    alarmTimer?.invalidate()
+    alarmTimer = nil
+  }
+  
+  private func invalidateMissionTimer() {
+    missionTimer?.invalidate()
+    missionTimer = nil
+  }
+  
+  @objc private func startMission() {
+    // 화면 상태를 갱신할 필요가 있음
+    onMissionStart()
+  }
+  
+  @objc private func timeoutMission() {
+    // 화면 상태를 갱신할 필요가 있음
+    onMissionTimeout()
+  }
+  
+  deinit {
+    alarmTimer?.invalidate()
+    missionTimer?.invalidate()
+  }
+}

--- a/PalangPalang/Sources/Domain/Model/AlarmModel.swift
+++ b/PalangPalang/Sources/Domain/Model/AlarmModel.swift
@@ -1,0 +1,20 @@
+//
+//  AlarmModel.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+struct AlarmModel: Storable {
+  var startDate: Date = .now
+  var dueDate: Date
+  var missionDueDate: Date {
+    return dueDate.addingTimeInterval(AlarmModel.timeLimit)
+  }
+  
+  static let storageKey: String = "alarm"
+  static let timeLimit: TimeInterval = 1
+}

--- a/PalangPalang/Sources/Domain/Model/AlarmSettingsModel.swift
+++ b/PalangPalang/Sources/Domain/Model/AlarmSettingsModel.swift
@@ -1,0 +1,72 @@
+//
+//  AlarmSettingsModel.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+struct AlarmSettingsModel {
+  @ValidHour var hour: String
+  @ValidMinutes var minutes: String
+  var isAM: Bool { return hour.toInt <= 12 }
+  
+  var alarmDate: Date? {
+    let calendar = Calendar.current
+    let now = Date()
+    
+    guard let alarmHour = Int(hour), let alarmMinutes = Int(minutes) else {
+      return nil // 알람 시간이 유효하지 않을 경우 nil 반환
+    }
+    
+    // 오늘의 알람 시간 설정
+    var components = calendar.dateComponents([.year, .month, .day], from: now)
+    components.hour = alarmHour
+    components.minute = alarmMinutes
+    components.second = 0
+    
+    guard let alarmDate = calendar.date(from: components) else {
+      return nil
+    }
+    
+    // 현재 시간보다 알람 시간이 이전이면 다음 날로 설정
+    if alarmDate <= now {
+      return calendar.date(byAdding: .day, value: 1, to: alarmDate)
+    }
+    
+    return alarmDate
+  }
+  
+  
+  init(hour: String, minutes: String) {
+    self.hour = hour
+    self.minutes = minutes
+  }
+  
+  // 현재 시각으로 시, 분 초기화
+  init() {
+    self.init(hour: "", minutes: "")
+    self.hour = getCurrentHour()
+    self.minutes = getCurrentMinute()
+  }
+  
+  private func getCurrentHour() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "H" // 24시간 형식
+    return dateFormatter.string(from: Date())
+  }
+  
+  private func getCurrentMinute() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "m" // 분 형식
+    return dateFormatter.string(from: Date())
+  }
+}
+
+private extension String {
+  var toInt: Int {
+    return Int(self) ?? 0
+  }
+}

--- a/PalangPalang/Sources/Domain/Model/AlarmState.swift
+++ b/PalangPalang/Sources/Domain/Model/AlarmState.swift
@@ -1,0 +1,16 @@
+//
+//  AppSceneState.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+enum AlarmState {
+  case alarmOnSettings
+  case alarmOnProcess
+  case missionOnProcess
+  case missionTimeout
+}

--- a/PalangPalang/Sources/Domain/Model/PropertyWrapper/ValidHour.swift
+++ b/PalangPalang/Sources/Domain/Model/PropertyWrapper/ValidHour.swift
@@ -1,0 +1,37 @@
+//
+//  ValidHour.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper
+struct ValidHour {
+  private var value: String
+  private let range = 0...24
+  private let initialValue = "00"
+  
+  var wrappedValue: String {
+    get { value }
+    set { value = ValidHour.validate(newValue, range: range, initialValue: initialValue) }
+  }
+  
+  init(wrappedValue: String) {
+    self.value = ValidHour.validate(wrappedValue, range: range, initialValue: initialValue)
+  }
+  
+  private static func validate(_ newValue: String, range: ClosedRange<Int>, initialValue: String) -> String {
+    if let intValue = Int(newValue), range.contains(intValue) {
+      return intValue < 10 ? "0\(intValue)" : "\(intValue)"
+    } else {
+      return initialValue
+    }
+  }
+  
+  static var availableHours: [String] {
+    (0...24).map { String(format: "%02d", $0) }
+  }
+}

--- a/PalangPalang/Sources/Domain/Model/PropertyWrapper/ValidMinutes.swift
+++ b/PalangPalang/Sources/Domain/Model/PropertyWrapper/ValidMinutes.swift
@@ -1,0 +1,37 @@
+//
+//  ValidMinutes.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper
+struct ValidMinutes {
+  private var value: String
+  private let range = 0...59
+  private let initialValue = "00"
+  
+  var wrappedValue: String {
+    get { value }
+    set { value = ValidMinutes.validate(newValue, range: range, initialValue: initialValue) }
+  }
+  
+  init(wrappedValue: String) {
+    self.value = ValidMinutes.validate(wrappedValue, range: range, initialValue: initialValue)
+  }
+  
+  private static func validate(_ newValue: String, range: ClosedRange<Int>, initialValue: String) -> String {
+    if let intValue = Int(newValue), range.contains(intValue) {
+      return intValue < 10 ? "0\(intValue)" : "\(intValue)"
+    } else {
+      return initialValue
+    }
+  }
+  
+  static var availableMinutes: [String] {
+    (0...59).map { String(format: "%02d", $0) }
+  }
+}

--- a/PalangPalang/Sources/Domain/Model/Storable.swift
+++ b/PalangPalang/Sources/Domain/Model/Storable.swift
@@ -1,0 +1,13 @@
+//
+//  Storable.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+protocol Storable: Codable {
+  static var storageKey: String { get }
+}

--- a/PalangPalang/Sources/Domain/UseCase/AlarmUseCase.swift
+++ b/PalangPalang/Sources/Domain/UseCase/AlarmUseCase.swift
@@ -1,0 +1,113 @@
+//
+//  AppStatusNotificationCentre.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+protocol AlarmSettings {
+  func addAlarm(alarm: AlarmModel)
+}
+
+protocol AlarmOnProcess {
+  func readMissionDate() -> Date?
+}
+
+protocol MissionOnProcess {
+  func readTimeoutDate() -> Date?
+  func deleteAlarm()
+}
+
+protocol CheckAlarmStatus {
+  func verifyAndChangeAlarmState()
+}
+
+@Observable
+class AlarmUseCase: CheckAlarmStatus {
+  static let shared = AlarmUseCase()
+  
+  
+  var alarmState: AlarmState = .alarmOnSettings
+  private var timerService: TimerSchedulerService?
+  
+  private init() {
+    self.verifyAndChangeAlarmState()
+    self.setupTimerService()
+  }
+  
+  private func setupTimerService() {
+    let alarm = DataStoreService<AlarmModel>.init().load()
+    timerService = TimerSchedulerService.init(
+      alarm: alarm,
+      onMissionStart: { [weak self] in
+        print("알람 끝/ 미션시작")
+        self?.verifyAndChangeAlarmState()
+      }, onMissionFinish: { [weak self] in
+        print("미션 TimeOver")
+        self?.verifyAndChangeAlarmState()
+      }
+    )
+  }
+  
+  /// 상태 갱신 요청
+  func verifyAndChangeAlarmState() {
+    let nowAlarm = DataStoreService<AlarmModel>().load()
+    self.alarmState = determineAppState(alarm: nowAlarm)
+  }
+  
+  /// Alarm 값을 토대로 Alarm 상태 분석
+  private func determineAppState(alarm: AlarmModel?) -> AlarmState {
+    let currentDate = Date()
+    
+    // AlarmModel이 없는 경우
+    guard let alarm = alarm else { return .alarmOnSettings }
+    
+    // AlarmModel이 있는 경우
+    if currentDate < alarm.dueDate {
+      return .alarmOnProcess
+    } else if currentDate < alarm.missionDueDate {
+      return .missionOnProcess
+    } else {
+      return .missionTimeout
+    }
+  }
+}
+
+extension AlarmUseCase: AlarmSettings {
+  func addAlarm(alarm: AlarmModel) {
+    DataStoreService<AlarmModel>.init().save(alarm)
+    LocalNotificationService.init().scheduleNotification(title: "미션시작", body: "귀신 퇴치하러 갑시당!", at: alarm.dueDate)
+    timerService?.scheduleAlarmAndMissionTimers(alarm)
+    verifyAndChangeAlarmState()
+  }
+}
+
+extension AlarmUseCase: AlarmOnProcess {
+  func readMissionDate() -> Date? {
+    if let dueDate = DataStoreService<AlarmModel>.init().load()?.dueDate {
+      return dueDate
+    } else {
+      verifyAndChangeAlarmState() // 데이터가 없다면 상태 갱신 요청
+      return nil
+    }
+  }
+}
+
+extension AlarmUseCase: MissionOnProcess {
+  func readTimeoutDate() -> Date? {
+    if let dueDate = DataStoreService<AlarmModel>.init().load()?.missionDueDate {
+      return dueDate
+    } else {
+      verifyAndChangeAlarmState() // 데이터가 없다면 상태 갱신 요청
+      return nil
+    }
+  }
+  
+  func deleteAlarm() {
+    DataStoreService<AlarmModel>.init().remove()
+    verifyAndChangeAlarmState()
+  }
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Alarm/AlarmOnProcessView.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Alarm/AlarmOnProcessView.swift
@@ -1,0 +1,19 @@
+//
+//  AlarmOnProcessView.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlarmOnProcessView: View {
+  var body: some View {
+    Text("RunningView")
+  }
+}
+
+#Preview {
+  AlarmOnProcessView()
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Mission/MissionCompletedView.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Mission/MissionCompletedView.swift
@@ -1,0 +1,19 @@
+//
+//  MissionCompletedView.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct MissionCompletedView: View {
+  var body: some View {
+    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  }
+}
+
+#Preview {
+  MissionCompletedView()
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Mission/MissionOnProcessView.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Mission/MissionOnProcessView.swift
@@ -1,0 +1,19 @@
+//
+//  MissionOnProcessView.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct MissionOnProcessView: View {
+  var body: some View {
+    Text("MissionView")
+  }
+}
+
+#Preview {
+  MissionOnProcessView()
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Mission/MissionTimeoutView.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Mission/MissionTimeoutView.swift
@@ -1,0 +1,23 @@
+//
+//  MissionTimeoutView.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct MissionTimeoutView: View {
+  var body: some View {
+    Button {
+      AlarmUseCase.shared.deleteAlarm()
+    } label: {
+      Text("MissionTimeoutView - 알림삭제")
+    }
+  }
+}
+
+#Preview {
+  MissionTimeoutView()
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmMain.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmMain.swift
@@ -1,0 +1,55 @@
+//
+//  AlarmMain.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlarmMain: View {
+  let alarmViewModel: AlarmViewModel
+
+  var body: some View {
+    Spacer()
+    Clock(alarm: alarmViewModel.state.alarm)
+    
+    Button(
+      action: {
+        alarmViewModel.effect(action: .tappedSettingsButton)
+      },
+      label: {
+        Text("설정하기")
+      }
+    )
+    
+    Spacer()
+    
+    Button(
+      action: {
+        alarmViewModel.effect(action: .tappedStartAlarm)
+      },
+      label: {
+        Text("시작하기")
+      }
+    )
+    .disabled(!alarmViewModel.state.readyForStart)
+  }
+}
+
+#Preview {
+  AlarmMain(alarmViewModel: .init())
+}
+
+private struct Clock: View {
+  let alarm: AlarmSettingsModel
+  
+  var body: some View {
+    HStack {
+      Text("\(alarm.hour)")
+      Text(":")
+      Text("\(alarm.minutes)")
+    }
+  }
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmMainView.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmMainView.swift
@@ -1,0 +1,27 @@
+//
+//  MainView.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlarmMainView: View {
+  let alarmViewModel: AlarmViewModel = .init()
+  
+  var body: some View {
+    VStack {
+      if !alarmViewModel.state.onSettings {
+        AlarmMain(alarmViewModel: alarmViewModel)
+      } else {
+        AlarmOnSettings(alarmViewModel: alarmViewModel)
+      }
+    }
+  }
+}
+
+#Preview {
+  AlarmMainView()
+}

--- a/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmOnSettings.swift
+++ b/PalangPalang/Sources/Presenters/Scenes/Settings/AlarmOnSettings.swift
@@ -1,0 +1,63 @@
+//
+//  AlarmOnSettings.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlarmOnSettings: View {
+  @Bindable var alarmViewModel: AlarmViewModel
+  
+  var body: some View {
+    VStack {
+      Text(alarmViewModel.state.alarm.isAM ? "AM" : "PM")
+      
+      ClockSetting(alarm: .init(
+        get: {alarmViewModel.state.alarm},
+        set: { alarmViewModel.effect(action: .changeAlarm($0)) }
+      )
+      )
+      .frame(height: 100)
+      
+      Button(
+        action: {
+          alarmViewModel.effect(action: .tappedSettingsDoneButton)
+        },
+        label: {
+          Text("설정완료")
+        }
+      )
+    }
+  }
+}
+
+#Preview {
+  AlarmOnSettings(alarmViewModel: .init())
+}
+
+private struct ClockSetting: View {
+  @Binding var alarm: AlarmSettingsModel
+  
+  var body: some View {
+    HStack {
+      Picker("시간", selection: $alarm.hour) {
+        ForEach(ValidHour.availableHours, id: \.self) { hour in
+          Text(hour)
+            .tag(hour)
+        }
+      }
+      .pickerStyle(WheelPickerStyle())
+      
+      Picker("분", selection: $alarm.minutes) {
+        ForEach(ValidMinutes.availableMinutes, id: \.self) { minute in
+          Text(minute)
+            .tag(minute)
+        }
+      }
+      .pickerStyle(WheelPickerStyle())
+    }
+  }
+}

--- a/PalangPalang/Sources/Presenters/ViewModel/AlarmViewModel.swift
+++ b/PalangPalang/Sources/Presenters/ViewModel/AlarmViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  AlarmViewModel.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+@Observable
+class AlarmViewModel {
+  struct State {
+    var alarm: AlarmSettingsModel = .init()
+    var formattedAlarmDate: String {
+      guard let alarmDate = alarm.alarmDate else {
+        return "Invalid Date"
+      }
+      
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+      dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+      
+      return dateFormatter.string(from: alarmDate)
+    }
+    var onSettings: Bool = false
+    var readyForStart: Bool = false
+  }
+  
+  enum Action {
+    case tappedSettingsButton
+    case tappedSettingsDoneButton
+    case changeAlarm(AlarmSettingsModel)
+    case tappedStartAlarm
+  }
+  
+  private(set) var state: State = .init()
+  private let useCase: AlarmSettings = AlarmUseCase.shared
+  
+  func effect(action: Action) {
+    switch action {
+    case .tappedSettingsButton:
+      state.onSettings = true
+    case .tappedSettingsDoneButton:
+      state.onSettings = false
+      state.readyForStart = true
+    case let .changeAlarm(newAlarm):
+      state.alarm = newAlarm
+    case .tappedStartAlarm:
+      guard let alarmDueDate = state.alarm.alarmDate else { print("알람 변환실패"); return }
+      let newAlarm = AlarmModel(dueDate: alarmDueDate)
+      useCase.addAlarm(alarm: newAlarm)
+      
+    }
+  }
+}

--- a/PalangPalang/Sources/Presenters/ViewModel/MissionViewModel.swift
+++ b/PalangPalang/Sources/Presenters/ViewModel/MissionViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  MissionViewModel.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/1/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation
+
+@Observable
+class MissionViewModel {
+  struct State {
+    
+  }
+  
+  enum Action {
+    
+  }
+  
+  private(set) var state: State = .init()
+}

--- a/PalangPalang/Sources/Presenters/ViewModel/SettingsViewModel.swift
+++ b/PalangPalang/Sources/Presenters/ViewModel/SettingsViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  SettingsViewModel.swift
+//  PalangPalang
+//
+//  Created by 박혜운 on 8/2/24.
+//  Copyright © 2024 com.mc3. All rights reserved.
+//
+
+import Foundation

--- a/PalangPalang/Tests/PalangPalangTests.swift
+++ b/PalangPalang/Tests/PalangPalangTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class PalangPalangTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2+2, 4)
+    }
+}


### PR DESCRIPTION
제목 양식 - 
### [Settings⚙️] #3 아키텍처 기본 구성 및 핵심 Alarm 로직 구성 
***   
### 연관 이슈 🧚
> #3 PalangPalang Architecture 🏗️


## 요약
> 전체적인 프로젝트 구조가 완성되었습니다 😍


## 작업 내용
### 1. AlarmUseCase - 싱글톤 / 알람 값을 책임지는 유일한 창구 
반드시 고유해야 하는 Alarm 값은 `AlarmUseCase`가 관리하며, 이는 `싱글톤`으로 작성되었습니다. 
`View`에서 곧장 `Domain` 레이어에 위치한 `AlarmUseCase`에 접근하는 상황은 찝찝함이 있으나 
`App` 진입 화면에서 `Alarm`의 상태에 따라 적절한 화면을 보여주는 상황이 앱의 핵심 도메인과 맞닿아 있다 판단하였습니다. 

`AlarmUseCase` 내부 기능은 필요 상황에 따라 protocol를 채택하는 형태로 구현되었습니다. 
이는 각각의 화면 진입이 AlarmUseCase의 어떤 기능만을 필요로 하는 지 제한, 명시하기 위함입니다. 
프로젝트가 단일 모듈인 만큼 엄격한 `의존성 주입`의 필요는 느끼지 못해 의존성 주입은 가져가지 않았습니다. 

### 2. `ViewModel` 분류 추가 
우리 앱 서비스는 특성상 `AlarmUseCase`에서 받은 정보를 화면에 올리기 위해 가공하는 작업이 까다롭다는 생각이 들었습니다! 
귀신이 날아다니는 형태, 애니메이션, 코어모션이 있어 뷰에 가까운 비즈니스로직을 처리할 `ViewModel` 구간이 있으면 좋을 것 같다 판단하였습니다. 
이후 폴더링 에서는 View와 ViewModel을 Presenters 레이어로 분류하였습니다. 

### 작업 스크린샷 (선택)
<img width="387" alt="image" src="https://github.com/user-attachments/assets/3c694bfd-1632-4b16-9d4c-de294197c594">   

프로젝트 소스코드는 위의 경로에 존재합니다! 
  
### 전체적인 프로젝트 구조 
<img width="366" alt="image" src="https://github.com/user-attachments/assets/16b79e07-201e-41be-b715-95e30bfcc59d">  



### `App`
<img width="184" alt="image" src="https://github.com/user-attachments/assets/138d286e-be51-4b4f-a64a-a1dd53bea11f">
  
화면 진입점에 해당합니다. 
앱의 실행과 동시에 점검해야 할 내용에 대한 판단을 이룹니다.

### `Presenters`  
<img width="216" alt="image" src="https://github.com/user-attachments/assets/f3e2316e-598c-48b4-899a-94439c6eaa3b">
  
<img width="210" alt="image" src="https://github.com/user-attachments/assets/bcc346c3-1f84-4d57-a2ae-28fe24ab0d16">
  
보여지는 것에 대한 책임 `Scenes`
<img width="307" alt="image" src="https://github.com/user-attachments/assets/3bfe89f3-2b39-4f2c-a499-05ad8dc3a6fb">
  
<img width="257" alt="image" src="https://github.com/user-attachments/assets/1edc08f2-0b64-4158-ad17-826c0cd145ff">
  
- 씬 ~ 에 해당하는 화면에만 `View`라는 이름을 붙이고 다른 화면은 붙이지 않습니다  
 
<img width="251" alt="image" src="https://github.com/user-attachments/assets/a7bfa2d0-cf5a-4555-8cbf-56bb0982a9f9">
  
화면 위에 올라갈 데이터를 적절한 형태로 가공하는 사용자 중심 비즈니스 로직 `ViewModel`

### `Domain`
<img width="221" alt="image" src="https://github.com/user-attachments/assets/a3842dbf-b7ff-4e69-a0cc-f78b5c2ceb98">  

`Alarm` 서비스의 정체성에 대한 서술  
우리 서비스의 경우, AlarmUseCase는 앱 내 Alarm 의 유일한 책임자 입니다 

### `Data`

<img width="250" alt="image" src="https://github.com/user-attachments/assets/bb2b1322-c552-4b35-9e2d-f70cd9f94a2c">

Domain의 기능을 구현하기 위해 선택한 것 중 구체적인 방법을 가진 객체의 집합 입니다  



## 공유사항 (선택)
> 화이~팅!! 다 함께 만나 다시 공유할게요!! 


<br>

---
격려의 한 마디 (선택) <br>
외마디 비명 (선택)
으악!! 