### PR TITLE
[🔥HOTFIX] #20 포어그라운드 상태에 들어섰을 때 초 상태 미갱신 문제 해결

### DIFF
--- a/PalangPalang/Sources/Presenters/ViewModel/AlarmOnProcessViewModel.swift
+++ b/PalangPalang/Sources/Presenters/ViewModel/AlarmOnProcessViewModel.swift
@@ -80,6 +80,8 @@ class AlarmOnProcessViewModel {
         self.state.timerM = timerInfo.minute
         self.state.timerS = timerInfo.seconds
         self.state.dueTime = dueTime
+        
+        self.dueDate = dueDate // 포그라운드 복귀 시 사용
         self.totalSecondsToDueDate = Double(timeIntervalStartToDue)
         
         startTimer(for: totalSeconds)
@@ -138,7 +140,6 @@ extension AlarmOnProcessViewModel {
   
   @objc private func verifyAndChangeTimerState() {
     guard let dueDate else { return }
-    
     let timeInterval = dueDate.timeIntervalSince(.now)
     let totalSeconds = Int(timeInterval)
     resetTimeRemaining(for: totalSeconds)


### PR DESCRIPTION
dueDate 초기화 코드 빠져있어 생긴 문제

### [카테고리]#20-포어그라운드 상태에 들어섰을 때 초 상태 미갱신 문제 해결
***   
## 요약
> ._onAppear 상황에서 dueDate 미갱신 문제 
```swift
func effect(action: Action) {
    switch action {
    case ._onAppear:
      if let (startDate, dueDate) = useCase.readAlarmDate() {
        let timeInterval = dueDate.timeIntervalSince(.now)
        let timeIntervalStartToDue = dueDate.timeIntervalSince(startDate)
        let totalSeconds = Int(timeInterval)
        
        let timerInfo = calculateTimeInterval(totalSeconds: totalSeconds)
        let dueTime = dueDateToString(dueDate)
        
        self.state.timerH = timerInfo.hour
        self.state.timerM = timerInfo.minute
        self.state.timerS = timerInfo.seconds
        self.state.dueTime = dueTime
        
        self.dueDate = dueDate // ⭐️ 포그라운드 복귀 시 사용 추가! ⭐️
        self.totalSecondsToDueDate = Double(timeIntervalStartToDue)
        
        startTimer(for: totalSeconds)
        connectAppDidBecomeActive()
      }
      return
```

<br>

---
격려의 한 마디 (선택) <br>
외마디 비명 (선택)

희희 급히 수정합니당! 
